### PR TITLE
Fix: Resolve 'cookies outside request scope' error on /tags page

### DIFF
--- a/app/tags/tag-page-client.tsx
+++ b/app/tags/tag-page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { AppSidebar } from "@/components/app-sidebar";
+import dynamic from "next/dynamic";
 import { format } from "date-fns"; // Removed unused date-fns imports
 import { Separator } from "@/components/ui/separator";
 import {
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/sidebar";
 import { TagManagement } from "@/components/tag-management";
 import { Todo, TodoTag } from "@/lib/types";
+
+const AppSidebar = dynamic(() => import('@/components/app-sidebar').then(mod => mod.AppSidebar), { ssr: false });
 
 interface TagPageClientProps {
   todos: Todo[];


### PR DESCRIPTION
The build process was failing with an error indicating that `cookies()` was being called outside of a request scope, specifically when collecting configuration for the /tags page.

This issue was traced back to the `AppSidebar` component, which uses the `useUser()` hook (from @stackframe/stack). This hook likely attempts to access cookies. When `AppSidebar` was rendered server-side as part of the `/tags` page pre-rendering or build process, it led to the error because there's no active HTTP request.

The fix involves dynamically importing `AppSidebar` within `app/tags/tag-page-client.tsx` using `next/dynamic` with the `ssr: false` option. This ensures that `AppSidebar` and, consequently, the `useUser()` hook, are only executed on the client-side where cookie access is valid within a request context.

While testing the build, other unrelated errors concerning missing environment variables (DATABASE_URL, NEXT_PUBLIC_STACK_PROJECT_ID) were encountered. These are pre-existing or environment-specific issues and are not addressed by this change. The primary 'cookies' error was not observed after this fix.