### PR TITLE
feat: Update todo order in DB on drag-and-drop

### DIFF
--- a/components/todo-list.tsx
+++ b/components/todo-list.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/tooltip";
 import { AddTodo } from "./add-todo";
 import type { Todo, TodoTag, TodoListProps } from "@/lib/types";
+import { updateTodoOrder } from "@/lib/actions";
 
 const ITEM_TYPE = "TODO_ITEM";
 
@@ -56,6 +57,19 @@ export function TodoList({
     const [removed] = updated.splice(dragIndex, 1);
     updated.splice(hoverIndex, 0, removed);
     setOrderedTodos(updated);
+
+    // Prepare data for the server action
+    const todosToUpdate = updated.map((todo, index) => ({
+      id: todo.id,
+      order: index,
+    }));
+
+    // Call the server action to update the order on the server
+    updateTodoOrder(todosToUpdate).catch((error) => {
+      console.error("Failed to update todo order on server:", error);
+      // Optionally, revert the local state change if the server update fails
+      // For now, we'll just log the error as per requirements
+    });
   };
 
   return (

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -131,3 +131,24 @@ export async function getCount(): Promise<any> {
     throw new Error("Failed to fetch count");
   }
 }
+
+// Server action to update the order of todos
+export async function updateTodoOrder(
+  todosToUpdate: { id: number; order: number }[],
+): Promise<void> {
+  try {
+    await prisma.$transaction(
+      todosToUpdate.map((todo) =>
+        prisma.todo.update({
+          where: { id: todo.id },
+          data: { order: todo.order },
+        }),
+      ),
+    );
+
+    revalidatePath("/");
+  } catch (error) {
+    console.error("Error updating todo order:", error);
+    throw new Error("Failed to update todo order");
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,7 @@
 export interface Todo {
   id: number;
   name: string;
-  order?: number; // Order of the todo in the list
+  order: number; // Order of the todo in the list
   description?: string;
   isComplete: boolean;
   dueDate?: string | Date;


### PR DESCRIPTION
This commit introduces the functionality to persist the order of todo items when they are re-arranged using drag-and-drop in the UI.

Changes include:
- Modified the `Todo` type in `lib/types.ts` to make the `order` field non-optional.
- Added a new server action `updateTodoOrder` in `lib/actions.ts`. This action takes an array of todo IDs and their new order, updating them in the database within a single transaction. It then calls `revalidatePath('/')` to refresh the UI.
- Updated the `moveTodo` function in `components/todo-list.tsx`. When a todo item is moved, this function now prepares an array of all displayed todos with their new order (based on their index in the list) and calls the `updateTodoOrder` server action to persist these changes.
- Basic error logging has been added for the server action and its invocation on the client side.